### PR TITLE
绩效考核额修改

### DIFF
--- a/Hanbell-KPI/src/java/cn/hanbell/kpi/control/ScorecardDetailPrintManagedBean.java
+++ b/Hanbell-KPI/src/java/cn/hanbell/kpi/control/ScorecardDetailPrintManagedBean.java
@@ -119,7 +119,7 @@ public class ScorecardDetailPrintManagedBean extends SuperSingleBean<ScorecardCo
             this.fileName = s.getName() + BaseLib.formatDate("yyyyMMddHHmmss", this.getDate()) + "." + "xls";
             String reportName = "";
             if (userManagedBean.getQ() == 1) {
-                reportName = reportPath + "scorecarddetail.rptdesign";
+                reportName = reportPath + "scorecarddetail1.rptdesign";
             } else if (userManagedBean.getQ() == 2) {
                 reportName = reportPath + "scorecarddetail2.rptdesign";
             } else if (userManagedBean.getQ() == 3) {

--- a/Hanbell-KPI/src/java/cn/hanbell/kpi/control/ScorecardSetManagedBean.java
+++ b/Hanbell-KPI/src/java/cn/hanbell/kpi/control/ScorecardSetManagedBean.java
@@ -78,6 +78,7 @@ public class ScorecardSetManagedBean extends SuperMultiBean<Scorecard, Scorecard
 
     protected Calendar c;
     private boolean freezed;
+    private boolean isSort;
 
     protected String queryDeptno;
     protected String queryDeptname;
@@ -308,7 +309,6 @@ public class ScorecardSetManagedBean extends SuperMultiBean<Scorecard, Scorecard
                     deletedDetailList.clear();
                     editedDetailList.clear();
                     addedDetailList.clear();
-
                     for (ScorecardDetail sd : detailList) {
                         ScorecardDetail detail = (ScorecardDetail) BeanUtils.cloneBean(sd);
                         detail.setId(null);
@@ -350,13 +350,22 @@ public class ScorecardSetManagedBean extends SuperMultiBean<Scorecard, Scorecard
         if (currentDetail.getFreezeDate() != null
                 && currentDetail.getFreezeDate().after(userManagedBean.getBaseDate())) {
             showErrorMsg("Error", "资料已经冻结,不可更新");
+             this.isSort=false;
             return;
         }
         for (ScorecardDetail detail : detailList) {
             if (!Objects.equals(currentDetail.getId(), detail.getId()) && currentDetail.getSeq() == detail.getSeq()) {
                 showErrorMsg("Error", "明细序号重复,不可更新");
+                 this.isSort=false;
                 return;
             }
+        }
+        if(this.isSort){
+            this.editedDetailList.clear();
+            this.editedDetailList.addAll(detailList);
+            super.doConfirmDetail();
+            this.isSort=false;
+            return ;
         }
         if (currentDetail.getGeneralScore() != null) {
             try {
@@ -925,6 +934,21 @@ public class ScorecardSetManagedBean extends SuperMultiBean<Scorecard, Scorecard
         }
     }
 
+    //修改明细排序
+    public void editSort() {
+        this.isSort=true;
+    }
+
+    @Override
+    public String edit(String path) {
+        //编辑页面时移除edit集合中的内容。关闭排序功能。
+        if("scorecardsetEdit".equals(path)){
+             this.isSort=false;
+             this.editedDetailList.clear();
+        }
+        return super.edit(path);
+    }
+
     /**
      * @description 查询不达标项
      */
@@ -1130,6 +1154,14 @@ public class ScorecardSetManagedBean extends SuperMultiBean<Scorecard, Scorecard
      */
     public boolean isLastDetail() {
         return lastDetail;
+    }
+
+    public boolean isIsSort() {
+        return isSort;
+    }
+
+    public void setIsSort(boolean isSort) {
+        this.isSort = isSort;
     }
 
 }

--- a/Hanbell-KPI/web/app/perf/scorecardsetEdit.xhtml
+++ b/Hanbell-KPI/web/app/perf/scorecardsetEdit.xhtml
@@ -165,6 +165,9 @@
                             <p:commandButton id="btnDeleteDetail" widgetVar="btnDeleteDetail" value="删除" actionListener="#{scorecardSetManagedBean.deleteDetail()}" icon="ui-icon-trash"
                                              oncomplete="PF('btnAddDetail').enable();PF('btnDeleteDetail').disable();PF('btnSaveDetail').disable();"
                                              process="@this" update=":formOne:tabView:plgDetail,:formOne:tabView:tableList" />
+                            <p:commandButton id="btnEditSort" widgetVar="btnEditSort" value="排序" actionListener="#{scorecardSetManagedBean.editSort()}" icon="ui-icon-trash"
+                                             oncomplete="PF('btnAddDetail').disable();PF('btnFillDetail').disable();PF('btnDeleteDetail').disable();PF('btnSaveDetail').disable();"
+                                             process="@this" update=":formOne:tabView:plgDetail,:formOne:tabView:tableList" />
                         </f:facet>
                         <f:facet name="right">
                             <p:commandButton id="btnFillDetail" widgetVar="btnFillDetail" value="填报"  icon="ui-icon-plus"
@@ -283,9 +286,9 @@
                             <p:column>
                                 <p:inputNumber id="rate" value="#{scorecardSetManagedBean.currentDetail.rate}" title="rate" />
                             </p:column>
-                            <p:column><p:outputLabel value="排序" for="seq" /></p:column>
+                            <p:column><p:outputLabel value="排序" for="seq"  /></p:column>
                             <p:column>
-                                <p:inputNumber id="seq" value="#{scorecardSetManagedBean.currentDetail.seq}" title="seq" />
+                            <p:inputNumber id="seq" value="#{scorecardSetManagedBean.currentDetail.seq}" title="seq" />
                             </p:column>
                         </p:row>
                         <p:row rendered="#{scorecardSetManagedBean.currentDetail.type=='N'}">
@@ -307,6 +310,13 @@
                                 oncomplete="PF('btnAddDetail').disable();PF('btnDeleteDetail').enable();PF('btnSaveDetail').enable();" />
                         <p:ajax event="rowUnselect" update=":formOne:tabView:plgDetail" oncomplete="" />
                         <p:ajax event="rowDblselect" update="formOne:dlgDetail" oncomplete="PF('dlgDetail').show();"/>
+                 
+                        <p:column rendered="#{scorecardSetManagedBean.isSort}">
+                            <f:facet name="header">
+                                <h:outputText value="排序"/>
+                            </f:facet>
+                            <p:inputText value="#{item.seq}"/>
+                        </p:column>
                         <p:column styleClass="Wid30">
                             <f:facet name="header">
                                 <h:outputText value="考核内容"/>

--- a/Hanbell-KPI/web/rpt/scorecarddetail1.rptdesign
+++ b/Hanbell-KPI/web/rpt/scorecarddetail1.rptdesign
@@ -1041,16 +1041,11 @@ currentRow = 0;
 ejbClient = new ScorecardReport();
 ejbClient.setEJB(params["JNDIName"]);
 master = ejbClient.getEntity(params["id"]);
-System.out.println("--------");
 if(master != null){
 	detail = ejbClient.getDetail(params["id"]);
 	auditorDetail = ejbClient.getAuditorDetail(params["id"],1);
 }
-var season = params["season"];
-System.out.println("--------");
-
-System.out.println("----detail----"+detail.size());
-System.out.println("----auditorDetail----"+auditorDetail.size());]]></method>
+var season = params["season"];]]></method>
             <method name="fetch"><![CDATA[importPackage( Packages.java.lang );
 auditor = "";
 if(currentRow < detail.size()){
@@ -1178,12 +1173,6 @@ return false;]]></method>
     <body>
         <table id="1669">
             <property name="dataSet">dataDetail</property>
-            <list-property name="visibility">
-                <structure>
-                    <property name="format">all</property>
-                    <expression name="valueExpr" type="javascript">params["season"].value == 1 ? false:true;</expression>
-                </structure>
-            </list-property>
             <list-property name="boundDataColumns">
                 <structure>
                     <property name="name">content</property>

--- a/Hanbell-KPI/web/rpt/scorecarddetail2.rptdesign
+++ b/Hanbell-KPI/web/rpt/scorecarddetail2.rptdesign
@@ -1043,13 +1043,10 @@ ejbClient.setEJB(params["JNDIName"]);
 master = ejbClient.getEntity(params["id"]);
 if(master != null){
 	detail = ejbClient.getDetail(params["id"]);
-	auditorDetail = ejbClient.getAuditorDetail(params["id"]);
+	auditorDetail = ejbClient.getAuditorDetail(params["id"],2);
 }
 var season = params["season"];
-System.out.println("--------");
-
-System.out.println("----detail----"+detail.size());
-System.out.println("----auditorDetail----"+auditorDetail.size());]]></method>
+]]></method>
             <method name="fetch"><![CDATA[importPackage( Packages.java.lang );
 auditor = "";
 if(currentRow < detail.size()){
@@ -1177,12 +1174,6 @@ return false;]]></method>
     <body>
         <table id="1509">
             <property name="dataSet">dataDetail</property>
-            <list-property name="visibility">
-                <structure>
-                    <property name="format">all</property>
-                    <expression name="valueExpr" type="javascript">params["season"].value == 2 ? false:true;</expression>
-                </structure>
-            </list-property>
             <list-property name="boundDataColumns">
                 <structure>
                     <property name="name">content</property>
@@ -1854,12 +1845,27 @@ return false;]]></method>
                         <property name="borderTopStyle">solid</property>
                         <property name="borderTopWidth">thin</property>
                         <property name="verticalAlign">middle</property>
+                        <label id="1957">
+                            <property name="fontSize">7pt</property>
+                            <text-property name="text">Q2部门说明</text-property>
+                        </label>
+                    </cell>
+                    <cell id="1520">
+                        <property name="borderBottomStyle">solid</property>
+                        <property name="borderBottomWidth">thin</property>
+                        <property name="borderLeftStyle">solid</property>
+                        <property name="borderLeftWidth">thin</property>
+                        <property name="borderRightStyle">solid</property>
+                        <property name="borderRightWidth">thin</property>
+                        <property name="borderTopStyle">solid</property>
+                        <property name="borderTopWidth">thin</property>
+                        <property name="verticalAlign">middle</property>
                         <label id="1607">
                             <property name="fontSize">7pt</property>
                             <text-property name="text">上半年目标值</text-property>
                         </label>
                     </cell>
-                    <cell id="1520">
+                    <cell id="1521">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -1874,7 +1880,7 @@ return false;]]></method>
                             <text-property name="text">上半年实际值</text-property>
                         </label>
                     </cell>
-                    <cell id="1521">
+                    <cell id="1522">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -1889,7 +1895,7 @@ return false;]]></method>
                             <text-property name="text">上半年达成率</text-property>
                         </label>
                     </cell>
-                    <cell id="1522">
+                    <cell id="1523">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -1904,7 +1910,7 @@ return false;]]></method>
                             <text-property name="text">部门说明</text-property>
                         </label>
                     </cell>
-                    <cell id="1523">
+                    <cell id="1524">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -1919,7 +1925,7 @@ return false;]]></method>
                             <text-property name="text">Q2分数</text-property>
                         </label>
                     </cell>
-                    <cell id="1524">
+                    <cell id="1525">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -1934,7 +1940,7 @@ return false;]]></method>
                             <text-property name="text">上半年分数</text-property>
                         </label>
                     </cell>
-                    <cell id="1525">
+                    <cell id="1526">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -1949,7 +1955,7 @@ return false;]]></method>
                             <text-property name="text">总经理说明</text-property>
                         </label>
                     </cell>
-                    <cell id="1526">
+                    <cell id="1527">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -1962,21 +1968,6 @@ return false;]]></method>
                         <label id="1614">
                             <property name="fontSize">7pt</property>
                             <text-property name="text">系数</text-property>
-                        </label>
-                    </cell>
-                    <cell id="1527">
-                        <property name="borderBottomStyle">solid</property>
-                        <property name="borderBottomWidth">thin</property>
-                        <property name="borderLeftStyle">solid</property>
-                        <property name="borderLeftWidth">thin</property>
-                        <property name="borderRightStyle">solid</property>
-                        <property name="borderRightWidth">thin</property>
-                        <property name="borderTopStyle">solid</property>
-                        <property name="borderTopWidth">thin</property>
-                        <property name="verticalAlign">middle</property>
-                        <label id="1615">
-                            <property name="fontSize">7pt</property>
-                            <text-property name="text">说明</text-property>
                         </label>
                     </cell>
                 </row>
@@ -2006,479 +1997,8 @@ return false;]]></method>
                         <property name="borderRightWidth">thin</property>
                         <property name="borderTopStyle">solid</property>
                         <property name="borderTopWidth">thin</property>
-                        <data id="1617">
+                        <data id="1968">
                             <property name="fontSize">7pt</property>
-                            <property name="dataSet">dataDetail</property>
-                            <list-property name="boundDataColumns">
-                                <structure>
-                                    <property name="name">content</property>
-                                    <text-property name="displayName">content</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["content"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">type</property>
-                                    <text-property name="displayName">type</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["type"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">name</property>
-                                    <text-property name="displayName">name</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["name"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">tq1</property>
-                                    <text-property name="displayName">tq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["tq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">tq2</property>
-                                    <text-property name="displayName">tq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["tq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">tq3</property>
-                                    <text-property name="displayName">tq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["tq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">tq4</property>
-                                    <text-property name="displayName">tq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["tq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">th1</property>
-                                    <text-property name="displayName">th1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["th1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">th2</property>
-                                    <text-property name="displayName">th2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["th2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">tfy</property>
-                                    <text-property name="displayName">tfy</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["tfy"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">bq1</property>
-                                    <text-property name="displayName">bq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["bq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">bq2</property>
-                                    <text-property name="displayName">bq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["bq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">bq3</property>
-                                    <text-property name="displayName">bq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["bq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">bq4</property>
-                                    <text-property name="displayName">bq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["bq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">bh1</property>
-                                    <text-property name="displayName">bh1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["bh1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">bh2</property>
-                                    <text-property name="displayName">bh2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["bh2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">bfy</property>
-                                    <text-property name="displayName">bfy</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["bfy"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">fq1</property>
-                                    <text-property name="displayName">fq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["fq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">fq2</property>
-                                    <text-property name="displayName">fq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["fq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">fq3</property>
-                                    <text-property name="displayName">fq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["fq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">fq4</property>
-                                    <text-property name="displayName">fq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["fq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">fh1</property>
-                                    <text-property name="displayName">fh1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["fh1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">fh2</property>
-                                    <text-property name="displayName">fh2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["fh2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">ffy</property>
-                                    <text-property name="displayName">ffy</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["ffy"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">aq1</property>
-                                    <text-property name="displayName">aq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["aq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">aq2</property>
-                                    <text-property name="displayName">aq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["aq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">aq3</property>
-                                    <text-property name="displayName">aq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["aq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">aq4</property>
-                                    <text-property name="displayName">aq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["aq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">ah1</property>
-                                    <text-property name="displayName">ah1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["ah1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">ah2</property>
-                                    <text-property name="displayName">ah2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["ah2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">afy</property>
-                                    <text-property name="displayName">afy</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["afy"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">pq1</property>
-                                    <text-property name="displayName">pq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["pq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">pq2</property>
-                                    <text-property name="displayName">pq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["pq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">pq3</property>
-                                    <text-property name="displayName">pq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["pq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">pq4</property>
-                                    <text-property name="displayName">pq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["pq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">ph1</property>
-                                    <text-property name="displayName">ph1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["ph1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">ph2</property>
-                                    <text-property name="displayName">ph2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["ph2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">pfy</property>
-                                    <text-property name="displayName">pfy</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["pfy"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">sq1</property>
-                                    <text-property name="displayName">sq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["sq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">sq2</property>
-                                    <text-property name="displayName">sq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["sq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">sq3</property>
-                                    <text-property name="displayName">sq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["sq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">sq4</property>
-                                    <text-property name="displayName">sq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["sq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">sh1</property>
-                                    <text-property name="displayName">sh1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["sh1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">sh2</property>
-                                    <text-property name="displayName">sh2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["sh2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">sfy</property>
-                                    <text-property name="displayName">sfy</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["sfy"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">cq1</property>
-                                    <text-property name="displayName">cq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["cq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">cq2</property>
-                                    <text-property name="displayName">cq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["cq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">cq3</property>
-                                    <text-property name="displayName">cq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["cq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">cq4</property>
-                                    <text-property name="displayName">cq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["cq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">ch1</property>
-                                    <text-property name="displayName">ch1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["ch1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">ch2</property>
-                                    <text-property name="displayName">ch2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["ch2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">cfy</property>
-                                    <text-property name="displayName">cfy</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["cfy"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">remark</property>
-                                    <text-property name="displayName">remark</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["remark"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">drq1</property>
-                                    <text-property name="displayName">drq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["drq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">drq2</property>
-                                    <text-property name="displayName">drq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["drq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">drq3</property>
-                                    <text-property name="displayName">drq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["drq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">drq4</property>
-                                    <text-property name="displayName">drq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["drq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">drh1</property>
-                                    <text-property name="displayName">drh1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["drh1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">drh2</property>
-                                    <text-property name="displayName">drh2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["drh2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">drfy</property>
-                                    <text-property name="displayName">drfy</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["drfy"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">mrq1</property>
-                                    <text-property name="displayName">mrq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["mrq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">mrq2</property>
-                                    <text-property name="displayName">mrq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["mrq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">mrq3</property>
-                                    <text-property name="displayName">mrq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["mrq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">mrq4</property>
-                                    <text-property name="displayName">mrq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["mrq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">mrh1</property>
-                                    <text-property name="displayName">mrh1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["mrh1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">mrh2</property>
-                                    <text-property name="displayName">mrh2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["mrh2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">mrfy</property>
-                                    <text-property name="displayName">mrfy</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["mrfy"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">seq</property>
-                                    <text-property name="displayName">seq</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["seq"]</expression>
-                                    <property name="dataType">integer</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">season</property>
-                                    <text-property name="displayName">season</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["season"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">msq1</property>
-                                    <text-property name="displayName">msq1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["msq1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">msq2</property>
-                                    <text-property name="displayName">msq2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["msq2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">msq3</property>
-                                    <text-property name="displayName">msq3</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["msq3"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">msq4</property>
-                                    <text-property name="displayName">msq4</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["msq4"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">msh1</property>
-                                    <text-property name="displayName">msh1</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["msh1"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">msh2</property>
-                                    <text-property name="displayName">msh2</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["msh2"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">symbol</property>
-                                    <text-property name="displayName">symbol</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["symbol"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">auditor</property>
-                                    <text-property name="displayName">auditor</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["auditor"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                                <structure>
-                                    <property name="name">weight</property>
-                                    <text-property name="displayName">weight</text-property>
-                                    <expression name="expression" type="javascript">dataSetRow["weight"]</expression>
-                                    <property name="dataType">string</property>
-                                </structure>
-                            </list-property>
                             <property name="resultSetColumn">weight</property>
                         </data>
                     </cell>
@@ -2575,12 +2095,26 @@ return false;]]></method>
                         <property name="borderRightWidth">thin</property>
                         <property name="borderTopStyle">solid</property>
                         <property name="borderTopWidth">thin</property>
+                        <data id="1628">
+                            <property name="fontSize">7pt</property>
+                            <property name="resultSetColumn">drq2</property>
+                        </data>
+                    </cell>
+                    <cell id="1538">
+                        <property name="borderBottomStyle">solid</property>
+                        <property name="borderBottomWidth">thin</property>
+                        <property name="borderLeftStyle">solid</property>
+                        <property name="borderLeftWidth">thin</property>
+                        <property name="borderRightStyle">solid</property>
+                        <property name="borderRightWidth">thin</property>
+                        <property name="borderTopStyle">solid</property>
+                        <property name="borderTopWidth">thin</property>
                         <data id="1625">
                             <property name="fontSize">7pt</property>
                             <property name="resultSetColumn">th1</property>
                         </data>
                     </cell>
-                    <cell id="1538">
+                    <cell id="1539">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -2594,7 +2128,7 @@ return false;]]></method>
                             <property name="resultSetColumn">ah1</property>
                         </data>
                     </cell>
-                    <cell id="1539">
+                    <cell id="1540">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -2608,20 +2142,6 @@ return false;]]></method>
                             <property name="resultSetColumn">ph1</property>
                         </data>
                     </cell>
-                    <cell id="1540">
-                        <property name="borderBottomStyle">solid</property>
-                        <property name="borderBottomWidth">thin</property>
-                        <property name="borderLeftStyle">solid</property>
-                        <property name="borderLeftWidth">thin</property>
-                        <property name="borderRightStyle">solid</property>
-                        <property name="borderRightWidth">thin</property>
-                        <property name="borderTopStyle">solid</property>
-                        <property name="borderTopWidth">thin</property>
-                        <data id="1628">
-                            <property name="fontSize">7pt</property>
-                            <property name="resultSetColumn">drq2</property>
-                        </data>
-                    </cell>
                     <cell id="1541">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
@@ -2631,9 +2151,9 @@ return false;]]></method>
                         <property name="borderRightWidth">thin</property>
                         <property name="borderTopStyle">solid</property>
                         <property name="borderTopWidth">thin</property>
-                        <data id="1629">
+                        <data id="1962">
                             <property name="fontSize">7pt</property>
-                            <property name="resultSetColumn">drq2</property>
+                            <property name="resultSetColumn">drh1</property>
                         </data>
                     </cell>
                     <cell id="1542">
@@ -2659,9 +2179,9 @@ return false;]]></method>
                         <property name="borderRightWidth">thin</property>
                         <property name="borderTopStyle">solid</property>
                         <property name="borderTopWidth">thin</property>
-                        <data id="1632">
+                        <data id="1960">
                             <property name="fontSize">7pt</property>
-                            <property name="resultSetColumn">mrq2</property>
+                            <property name="resultSetColumn">sh1</property>
                         </data>
                     </cell>
                     <cell id="1544">
@@ -2673,9 +2193,9 @@ return false;]]></method>
                         <property name="borderRightWidth">thin</property>
                         <property name="borderTopStyle">solid</property>
                         <property name="borderTopWidth">thin</property>
-                        <data id="1633">
+                        <data id="1632">
                             <property name="fontSize">7pt</property>
-                            <property name="resultSetColumn">cq2</property>
+                            <property name="resultSetColumn">mrq2</property>
                         </data>
                     </cell>
                     <cell id="1545">
@@ -2687,9 +2207,9 @@ return false;]]></method>
                         <property name="borderRightWidth">thin</property>
                         <property name="borderTopStyle">solid</property>
                         <property name="borderTopWidth">thin</property>
-                        <data id="1634">
+                        <data id="1633">
                             <property name="fontSize">7pt</property>
-                            <property name="resultSetColumn">remark</property>
+                            <property name="resultSetColumn">cq2</property>
                         </data>
                     </cell>
                 </row>
@@ -2829,12 +2349,22 @@ return false;]]></method>
                         <property name="borderRightWidth">thin</property>
                         <property name="borderTopStyle">solid</property>
                         <property name="borderTopWidth">thin</property>
+                    </cell>
+                    <cell id="1560">
+                        <property name="borderBottomStyle">solid</property>
+                        <property name="borderBottomWidth">thin</property>
+                        <property name="borderLeftStyle">solid</property>
+                        <property name="borderLeftWidth">thin</property>
+                        <property name="borderRightStyle">solid</property>
+                        <property name="borderRightWidth">thin</property>
+                        <property name="borderTopStyle">solid</property>
+                        <property name="borderTopWidth">thin</property>
                         <data id="1635">
                             <property name="fontSize">7pt</property>
                             <property name="resultSetColumn">msq2</property>
                         </data>
                     </cell>
-                    <cell id="1560">
+                    <cell id="1561">
                         <property name="borderBottomStyle">solid</property>
                         <property name="borderBottomWidth">thin</property>
                         <property name="borderLeftStyle">solid</property>
@@ -2847,16 +2377,6 @@ return false;]]></method>
                             <property name="fontSize">7pt</property>
                             <property name="resultSetColumn">msh1</property>
                         </data>
-                    </cell>
-                    <cell id="1561">
-                        <property name="borderBottomStyle">solid</property>
-                        <property name="borderBottomWidth">thin</property>
-                        <property name="borderLeftStyle">solid</property>
-                        <property name="borderLeftWidth">thin</property>
-                        <property name="borderRightStyle">solid</property>
-                        <property name="borderRightWidth">thin</property>
-                        <property name="borderTopStyle">solid</property>
-                        <property name="borderTopWidth">thin</property>
                     </cell>
                     <cell id="1562">
                         <property name="borderBottomStyle">solid</property>

--- a/Hanbell-KPI/web/rpt/scorecarddetail3.rptdesign
+++ b/Hanbell-KPI/web/rpt/scorecarddetail3.rptdesign
@@ -1043,7 +1043,7 @@ ejbClient.setEJB(params["JNDIName"]);
 master = ejbClient.getEntity(params["id"]);
 if(master != null){
 	detail = ejbClient.getDetail(params["id"]);
-	auditorDetail = ejbClient.getAuditorDetail(params["id"],params["season"]);
+	auditorDetail = ejbClient.getAuditorDetail(params["id"],3);
 }
 var season = params["season"];]]></method>
             <method name="fetch"><![CDATA[importPackage( Packages.java.lang );

--- a/Hanbell-KPI/web/rpt/scorecarddetail4.rptdesign
+++ b/Hanbell-KPI/web/rpt/scorecarddetail4.rptdesign
@@ -1043,13 +1043,9 @@ ejbClient.setEJB(params["JNDIName"]);
 master = ejbClient.getEntity(params["id"]);
 if(master != null){
 	detail = ejbClient.getDetail(params["id"]);
-	auditorDetail = ejbClient.getAuditorDetail(params["id"]);
+	auditorDetail = ejbClient.getAuditorDetail(params["id"],2);
 }
-var season = params["season"];
-System.out.println("--------");
-
-System.out.println("----detail----"+detail.size());
-System.out.println("----auditorDetail----"+auditorDetail.size());]]></method>
+var season = params["season"];]]></method>
             <method name="fetch"><![CDATA[importPackage( Packages.java.lang );
 auditor = "";
 if(currentRow < detail.size()){

--- a/KPI-ejb/src/java/cn/hanbell/kpi/ejb/ScorecardAuditorBean.java
+++ b/KPI-ejb/src/java/cn/hanbell/kpi/ejb/ScorecardAuditorBean.java
@@ -34,8 +34,8 @@ public class ScorecardAuditorBean extends SuperEJBForKPI<ScorecardAuditor> {
             return null;
         }
     }
-    
-        public List<ScorecardAuditor> findByPidAndQuarter(int pid,int seq,int quarter) {
+
+    public List<ScorecardAuditor> findByPidAndQuarter(int pid, int seq, int quarter) {
         Query query = getEntityManager().createNamedQuery("ScorecardAuditor.findByPidAndSeqAndQuarter");
         query.setParameter("pid", pid);
         query.setParameter("seq", seq);
@@ -46,5 +46,4 @@ public class ScorecardAuditorBean extends SuperEJBForKPI<ScorecardAuditor> {
             return null;
         }
     }
-
 }

--- a/KPI-ejb/src/java/cn/hanbell/kpi/ejb/ScorecardBean.java
+++ b/KPI-ejb/src/java/cn/hanbell/kpi/ejb/ScorecardBean.java
@@ -130,9 +130,8 @@ public class ScorecardBean extends SuperEJBForKPI<Scorecard> {
 
     public List<ScorecardAuditor> getAuditorDetail1(Object value, int quater) {
         List<ScorecardAuditor> list = scorecardAuditorBean.findByPId(value);
-       list.removeIf(auditor -> auditor.getQuarter() != quater);
+        list.removeIf(auditor -> auditor.getQuarter() != quater);
         return list;
-
     }
 
     public BigDecimal getContentScores(List<ScorecardContent> detail, String column) throws Exception {

--- a/KPI-ejb/src/java/cn/hanbell/kpi/ejb/ScorecardDetailBean.java
+++ b/KPI-ejb/src/java/cn/hanbell/kpi/ejb/ScorecardDetailBean.java
@@ -122,7 +122,7 @@ public class ScorecardDetailBean extends SuperEJBForKPI<ScorecardDetail> {
         return super.update(entity);
     }
 
-    public ScorecardDetail findByPidAndContent(int pid,String content) {
+    public ScorecardDetail findByPidAndContent(int pid, String content) {
         Query query = getEntityManager().createNamedQuery("ScorecardDetail.findByPidAndContent");
         query.setParameter("pid", pid);
         query.setParameter("content", content);
@@ -132,39 +132,32 @@ public class ScorecardDetailBean extends SuperEJBForKPI<ScorecardDetail> {
             return null;
         }
     }
-    
+
     //把&lt;br /&gt;格式变成\r\n的格式
-      public String formatEAPEnt(Object value) {
+    public String formatEAPEnt(Object value) {
         if (value == null) {
             return "";
         }
         String v = String.valueOf(value);
-
         Matcher m = Pattern.compile("(?m)^.*$").matcher(v);
         StringBuffer resultValue = new StringBuffer();
         while (m.find()) {
             resultValue.append(m.group()).append("\r\n");
         }
         return resultValue.toString().trim().replaceAll("<br />", "\r\n");
-
     }
-      
-      //把\r\n格式变成&lt;br /&gt;的格式
-      public String formatOAEnt(Object value) {
+
+    public String formatOAEnt(Object value) {
         if (value == null) {
             return "";
-        }
-        String v = String.valueOf(value);
-
-        Matcher m = Pattern.compile("(?m)^.*$").matcher(v);
-        StringBuffer resultValue = new StringBuffer();
-        while (m.find()) {
-            resultValue.append(m.group().replaceAll("&", "").trim()).append("&lt;br /&gt;");
-        }
-        if (resultValue.toString().endsWith("&lt;br /&gt;")) {
-            return resultValue.substring(0, resultValue.length() - 12);
         } else {
-            return resultValue.toString();
+            String v = String.valueOf(value);
+            Matcher m = Pattern.compile("(?m)^.*$").matcher(v);
+            StringBuffer resultValue = new StringBuffer();
+            while (m.find()) {
+                resultValue.append(m.group().trim()).append("&lt;br /&gt;");
+            }
+            return resultValue.toString().endsWith("&lt;br /&gt;") ? resultValue.substring(0, resultValue.length() - 12) : resultValue.toString();
         }
     }
 }

--- a/KPI-ejb/src/java/cn/hanbell/kpi/entity/ScorecardAuditor.java
+++ b/KPI-ejb/src/java/cn/hanbell/kpi/entity/ScorecardAuditor.java
@@ -26,7 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @NamedQueries({
     @NamedQuery(name = "ScorecardAuditor.findAll", query = "SELECT s FROM ScorecardAuditor s"),
     @NamedQuery(name = "ScorecardAuditor.findById", query = "SELECT s FROM ScorecardAuditor s WHERE s.id = :id"),
-    @NamedQuery(name = "ScorecardAuditor.findByPId", query = "SELECT s FROM ScorecardAuditor s WHERE s.pid = :pid"),
+    @NamedQuery(name = "ScorecardAuditor.findByPId", query = "SELECT s FROM ScorecardAuditor s WHERE s.pid = :pid ORDER BY s.credate ASC"),
     @NamedQuery(name = "ScorecardAuditor.findByAuditorId", query = "SELECT s FROM ScorecardAuditor s WHERE s.auditorId = :auditorId"),
     @NamedQuery(name = "ScorecardAuditor.findByAuditorName", query = "SELECT s FROM ScorecardAuditor s WHERE s.auditorName = :auditorName"),
     @NamedQuery(name = "ScorecardAuditor.findByRemark", query = "SELECT s FROM ScorecardAuditor s WHERE s.remark = :remark"),
@@ -38,7 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
     @NamedQuery(name = "ScorecardAuditor.findByCfmuser", query = "SELECT s FROM ScorecardAuditor s WHERE s.cfmuser = :cfmuser"),
     @NamedQuery(name = "ScorecardAuditor.findByCfmdate", query = "SELECT s FROM ScorecardAuditor s WHERE s.cfmdate = :cfmdate"),
     @NamedQuery(name = "ScorecardAuditor.findByPidAndAuditorId", query = "SELECT s FROM ScorecardAuditor s WHERE s.pid = :pid AND s.auditorId = :auditorId"),
-    @NamedQuery(name = "ScorecardAuditor.findByPidAndSeqAndQuarter", query = "SELECT s FROM ScorecardAuditor s WHERE s.pid = :pid AND s.seq = :seq AND s.quarter =:quarter ")})
+    @NamedQuery(name = "ScorecardAuditor.findByPidAndSeqAndQuarter", query = "SELECT s FROM ScorecardAuditor s WHERE s.pid = :pid AND s.seq = :seq AND s.quarter =:quarter ORDER BY s.credate ASC")})
 public class ScorecardAuditor extends SuperEntity {
 
     @JoinColumn(name = "pid", referencedColumnName = "id", updatable = false, insertable = false)

--- a/KPI-ejb/src/java/cn/hanbell/kpi/evaluation/FreeServiceOuterFW1G.java
+++ b/KPI-ejb/src/java/cn/hanbell/kpi/evaluation/FreeServiceOuterFW1G.java
@@ -19,7 +19,7 @@ public class FreeServiceOuterFW1G extends FreeServiceOuterFW {
         super();
         queryParams.put("facno", "C");
 //        queryParams.put("hmark1", " <> 'CK' ");
-        queryParams.put("hmark1", " in ('HD') ");
+        queryParams.put("hmark1", "not in ('HN','CK') ");
         queryParams.put("hmark2", " ='AH' ");
     }
 


### PR DESCRIPTION
         1.部门说明超过200字，无法抛转OA
         2.文本中含有"%","<",">"此三个特殊符号。无法抛转OA
         3.解决审核人没按照OA顺序显示。（OA回写审核人时插入审核时间，前台按照审核时间排序）
         4.调整了 批量导出和单独导出指向同一个模板。用于不符合规范的部门可以单独导出。
         5.绩效考核新增排序栏位
         6.进入编辑页面时，清空上一个修改的集合。防止之前明细错位。。